### PR TITLE
Adding python3 version for `preprocess`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ code/data/*.csv
 code/data/cache
 code/data/bio_nlp_vec
 code/data/*.txt
+
+# Jupyter notebook checkpoints
+.ipynb_checkpoints

--- a/code/python3/preprocess.ipynb
+++ b/code/python3/preprocess.ipynb
@@ -419,13 +419,13 @@
    "source": [
     "import pickle\n",
     "\n",
-    "print topicd9[:10]\n",
+    "print (topicd9[:10])\n",
     "pickle.dump(topicd9[:10], open( \"./data/ICD9CODES_TOP10.p\", \"wb\" ))\n",
-    "print topicd9[:50]\n",
+    "print (topicd9[:50])\n",
     "pickle.dump(topicd9[:50], open( \"./data/ICD9CODES_TOP50.p\", \"wb\" ))\n",
-    "print topicd9[50:60]\n",
+    "print (topicd9[50:60])\n",
     "pickle.dump(topicd9[50:60], open( \"./data/ICD9CAT_TOP10.p\", \"wb\" ))\n",
-    "print topicd9[50:]\n",
+    "print (topicd9[50:])\n",
     "pickle.dump(topicd9[50:], open( \"./data/ICD9CAT_TOP50.p\", \"wb\" ))"
    ]
   },

--- a/code/python3/preprocess.ipynb
+++ b/code/python3/preprocess.ipynb
@@ -1,0 +1,635 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MIMIC III Preprocessing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Input:\n",
+    "  * ./data/NOTEEVENTS-2.csv (contains clinical notes / text)\n",
+    "  * ./data/DIAGNOSES_ICD.csv (contains admission to ICD9 code diagnosis)\n",
+    "  * ./data/D_ICD_DIAGNOSES.csv (contains the ICD9 code description)\n",
+    "* Output:\n",
+    "  * ./data/DATA_HADM (contains top 50 icd9code, top 50 icd9cat, and clinical text for each admission)\n",
+    "  * ./data/DATA_HADM_CLEANED (contains top 50 icd9code, top 50 icd9cat, and cleaned clinical text w/out stopwords for each admission)\n",
+    "  * ./data/ICD9CODES.p (pickle file of all ICD9 codes)\n",
+    "  * ./data/ICD9CODES_TOP10.p (pickle file of top 10 ICD9 codes)\n",
+    "  * ./data/ICD9CODES_TOP50.p (pickle file of top 50 ICD9 codes)\n",
+    "  * ./data/ICD9CAT_TOP10.p (pickle file of top 10 ICD9 categories)\n",
+    "  * ./data/ICD9CAT_TOP50.p (pickle file of top 50 ICD9 categories)\n",
+    "* Description: converts the raw MIMIC III csv files into multi-labels-and-texts csv format. The output of this notebook are dumped in corresponding folders, which is merged by merge_data.sh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization and Data Loading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark import SparkContext, SparkConf\n",
+    "from pyspark.sql.types import *\n",
+    "import pyspark.sql.functions as F\n",
+    "from pyspark.sql import SparkSession"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('row_id', 'int'), ('subject_id', 'int'), ('hadm_id', 'int'), ('chartdate', 'date'), ('category', 'string'), ('description', 'string'), ('cgid', 'int'), ('iserror', 'int'), ('text', 'string')]\n",
+      "[('row_id', 'int'), ('subject_id', 'int'), ('hadm_id', 'int'), ('seq_num', 'int'), ('icd9_code', 'string'), ('icd9_cat', 'string')]\n",
+      "[('row_id', 'bigint'), ('subject_id', 'bigint'), ('hadm_id', 'bigint'), ('seq_num', 'bigint'), ('icd9_code', 'string'), ('icd9_cat', 'string')]\n",
+      "[('hadm_id', 'int')]\n",
+      "[('subject_id', 'int')]\n",
+      "[('ROW_ID', 'int'), ('ICD9_CODE', 'string'), ('SHORT_TITLE', 'string'), ('LONG_TITLE', 'string')]\n",
+      "[('row_id', 'bigint'), ('subject_id', 'bigint'), ('hadm_id', 'bigint'), ('seq_num', 'bigint'), ('icd9_code', 'string'), ('icd9_cat', 'string')]\n",
+      "[('row_id', 'int'), ('subject_id', 'int'), ('hadm_id', 'int'), ('seq_num', 'int'), ('icd9_code', 'string'), ('icd9_cat', 'string')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "conf = SparkConf().setAppName(\"preprocess\").setMaster(\"local\")\n",
+    "sc = SparkContext.getOrCreate(conf)\n",
+    "spark = SparkSession.builder.master(\"local\").appName(\"preprocess\").getOrCreate()\n",
+    "\n",
+    "ne_struct = StructType([StructField(\"row_id\", IntegerType(), True),\n",
+    "                      StructField(\"subject_id\", IntegerType(), True),\n",
+    "                      StructField(\"hadm_id\", IntegerType(), True),\n",
+    "                      StructField(\"chartdate\", DateType(), True),\n",
+    "                      StructField(\"category\", StringType(), True),\n",
+    "                      StructField(\"description\", StringType(), True),\n",
+    "                      StructField(\"cgid\", IntegerType(), True),\n",
+    "                      StructField(\"iserror\", IntegerType(), True),\n",
+    "                      StructField(\"text\", StringType(), True)])\n",
+    "df_ne = spark.read.csv(\"./data/NOTEEVENTS-2.csv\",\n",
+    "# df_ne = spark.read.csv(\"./data/NOTEEVENTS-2sample.csv\",\n",
+    "                       header=True,\n",
+    "                       schema=ne_struct)\n",
+    "df_ne.registerTempTable(\"noteevents\")\n",
+    "df_ne.filter(df_ne.category==\"Discharge summary\") \\\n",
+    "    .registerTempTable(\"noteevents2\")\n",
+    "    \n",
+    "# i want to cache noteevents, but it's too big\n",
+    "\n",
+    "# many icd to one hadm_id\n",
+    "diag_struct = StructType([StructField(\"ROW_ID\", IntegerType(), True),\n",
+    "                          StructField(\"SUBJECT_ID\", IntegerType(), True),\n",
+    "                          StructField(\"HADM_ID\", IntegerType(), True),\n",
+    "                          StructField(\"SEQ_NUM\", IntegerType(), True),\n",
+    "                          StructField(\"ICD9_CODE\", StringType(), True)])\n",
+    "df_diag_m = spark.read.csv(\"./data/DIAGNOSES_ICD.csv\",\n",
+    "                           header=True,\n",
+    "                           schema=diag_struct) \\\n",
+    "            .selectExpr(\"ROW_ID as row_id\", \n",
+    "                        \"SUBJECT_ID as subject_id\",\n",
+    "                        \"HADM_ID as hadm_id\",\n",
+    "                        \"SEQ_NUM as seq_num\",\n",
+    "                        \"ICD9_CODE as icd9_code\")\n",
+    "# added to filter out categories\n",
+    "geticd9cat_udf = F.udf(lambda x: str(x)[:3], StringType())\n",
+    "df_diag_m = df_diag_m.withColumn(\"icd9_cat\", geticd9cat_udf(\"icd9_code\"))\n",
+    "df_diag_m.registerTempTable(\"diagnoses_icd_m\")\n",
+    "df_diag_m.cache()\n",
+    "\n",
+    "# one icd to one hadm_id (take the smallest seq number as primary)\n",
+    "diag_o_rdd = df_diag_m.rdd.sortBy(lambda x: (x.hadm_id, x.subject_id, x.seq_num)) \\\n",
+    "    .groupBy(lambda x: x.hadm_id) \\\n",
+    "    .mapValues(list) \\\n",
+    "    .reduceByKey(lambda x, y: x if x.seq_num < y.seq_num else y) \\\n",
+    "    .map(lambda hid_d: hid_d[1][0])\n",
+    "\n",
+    "df_diag_o = spark.createDataFrame(diag_o_rdd)\n",
+    "df_diag_o.registerTempTable(\"diagnoses_icd_o\")\n",
+    "df_diag_o.cache()\n",
+    "\n",
+    "# get hadm_id list in noteevents\n",
+    "df_hadm_id_list = spark.sql(\"\"\"\n",
+    "SELECT DISTINCT hadm_id FROM noteevents2\n",
+    "\"\"\")\n",
+    "df_hadm_id_list.registerTempTable(\"hadm_id_list\")\n",
+    "df_hadm_id_list.cache()\n",
+    "\n",
+    "# get subject_id list in noteevents\n",
+    "df_subject_id_list = spark.sql(\"\"\"\n",
+    "SELECT DISTINCT subject_id FROM noteevents2\n",
+    "\"\"\")\n",
+    "df_subject_id_list.registerTempTable(\"subject_id_list\")\n",
+    "df_subject_id_list.cache()\n",
+    "\n",
+    "df_icd9desc = spark.read.csv(\"./data/D_ICD_DIAGNOSES.csv\",\n",
+    "                       header=True, inferSchema=True)\n",
+    "df_icd9desc.registerTempTable(\"diagnoses_icd_desc\")\n",
+    "\n",
+    "df_diag_o2 = spark.sql(\"\"\"\n",
+    "SELECT row_id, subject_id, diagnoses_icd_o.hadm_id AS hadm_id,\n",
+    "seq_num, icd9_code, icd9_cat\n",
+    "FROM diagnoses_icd_o JOIN hadm_id_list\n",
+    "ON diagnoses_icd_o.hadm_id = hadm_id_list.hadm_id\n",
+    "\"\"\")\n",
+    "df_diag_o2.registerTempTable(\"diagnoses_icd_o2\")\n",
+    "df_diag_o2.cache()\n",
+    "\n",
+    "df_diag_m2 = spark.sql(\"\"\"\n",
+    "SELECT row_id, subject_id, diagnoses_icd_m.hadm_id AS hadm_id,\n",
+    "seq_num, icd9_code, icd9_cat\n",
+    "FROM diagnoses_icd_m JOIN hadm_id_list\n",
+    "ON diagnoses_icd_m.hadm_id = hadm_id_list.hadm_id\n",
+    "\"\"\")\n",
+    "df_diag_m2.registerTempTable(\"diagnoses_icd_m2\")\n",
+    "df_diag_m2.cache()\n",
+    "\n",
+    "print (df_ne.dtypes)\n",
+    "print (df_diag_m.dtypes)\n",
+    "print (df_diag_o.dtypes)\n",
+    "print (df_hadm_id_list.dtypes)\n",
+    "print (df_subject_id_list.dtypes)\n",
+    "print (df_icd9desc.dtypes)\n",
+    "print (df_diag_o2.dtypes)\n",
+    "print (df_diag_m2.dtypes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Preprocessing (all icd9 codes)\n",
+    "\n",
+    "Returns RDD[(hadm_id, list(icd9_codes))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "icd9code_score_hadm = spark.sql(\"\"\"\n",
+    "SELECT icd9_code, COUNT(DISTINCT hadm_id) AS score\n",
+    "FROM diagnoses_icd_m2\n",
+    "GROUP BY icd9_code\n",
+    "\"\"\").rdd.cache()\n",
+    "\n",
+    "icd9code_score_subj = spark.sql(\"\"\"\n",
+    "SELECT icd9_code, COUNT(DISTINCT subject_id) AS score\n",
+    "FROM diagnoses_icd_m2\n",
+    "GROUP BY icd9_code\n",
+    "\"\"\").rdd.cache()\n",
+    "\n",
+    "icd9cat_score_hadm = spark.sql(\"\"\"\n",
+    "SELECT icd9_cat AS icd9_code, COUNT(DISTINCT hadm_id) AS score\n",
+    "FROM diagnoses_icd_m2\n",
+    "GROUP BY icd9_cat\n",
+    "\"\"\").rdd.cache()\n",
+    "\n",
+    "icd9cat_score_subj = spark.sql(\"\"\"\n",
+    "SELECT icd9_cat AS icd9_code, COUNT(DISTINCT subject_id) AS score\n",
+    "FROM diagnoses_icd_m2\n",
+    "GROUP BY icd9_cat\n",
+    "\"\"\").rdd.cache()\n",
+    "\n",
+    "def get_id_to_topicd9(id_type, icdcode, topX):\n",
+    "    if id_type == \"hadm_id\" and icdcode:\n",
+    "        icd9_score = icd9code_score_hadm\n",
+    "    elif id_type == \"hadm_id\" and not icdcode:\n",
+    "        icd9_score = icd9cat_score_hadm\n",
+    "    elif id_type == \"subject_id\" and icdcode:\n",
+    "        icd9_score = icd9code_score_subj\n",
+    "    elif id_type == \"subject_id\" and not icdcode:\n",
+    "        icd9_score = icd9cat_score_subj\n",
+    "    else: #default\n",
+    "        icd9_score = icd9code_score_hadm\n",
+    "    \n",
+    "        \n",
+    "    icd9_topX2 = [i.icd9_code for i in icd9_score.takeOrdered(topX, key=lambda x: -x.score)]\n",
+    "    if not icdcode:\n",
+    "        icd9_topX2 = ['c'+str(i) for i in icd9_topX2]\n",
+    "    else:\n",
+    "        icd9_topX2 = [str(i) for i in icd9_topX2]\n",
+    "    icd9_topX = set(icd9_topX2)\n",
+    "    \n",
+    "    id_to_topicd9 = df_diag_m2.rdd \\\n",
+    "        .map(lambda x: (x.hadm_id if id_type==\"hadm_id\" else x.subject_id, x.icd9_code if icdcode else 'c'+str(x.icd9_cat))) \\\n",
+    "        .groupByKey() \\\n",
+    "        .mapValues(lambda x: set(x) & icd9_topX) \\\n",
+    "        .filter(lambda x_y: x_y[1])\n",
+    "        \n",
+    "    return id_to_topicd9, list(icd9_topX2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(PythonRDD[123] at RDD at PythonRDD.scala:53, ['4019', '4280', '42731', '41401', '5849', '25000', '2724', '51881', '5990', '53081', '2720', '2859', '2449', '486', '2851', '2762', '496', '99592', 'V5861', '5070', '0389', '5859', '40390', '311', '3051', '412', '2875', '41071', '2761', 'V4581', '4240', 'V1582', '5119', 'V4582', '40391', 'V290', '4241', '78552', 'V5867', '42789', '32723', '9971', '5845', '2760', '7742', '5180', 'V053', '4168', '49390', '2767'])\n",
+      "(PythonRDD[129] at RDD at PythonRDD.scala:53, ['4019', '41401', '42731', '4280', '5849', '2724', '25000', '51881', '5990', '2720', '53081', '2859', '486', '2851', '2762', '2449', '496', '99592', '5070', '0389', 'V5861', '3051', '41071', '311', '5859', '40390', '2761', '2875', '412', '4240', '5119', 'V290', 'V1582', '78552', '4241', '9971', '42789', 'V4581', 'V4582', '7742', '5845', 'V053', '5180', '2760', '45829', 'V5867', '2767', '4589', '4168', '5185'])\n",
+      "(PythonRDD[135] at RDD at PythonRDD.scala:53, ['c401', 'c427', 'c276', 'c272', 'c414', 'c250', 'c428', 'c518', 'c285', 'c584', 'cV45', 'c599', 'c530', 'cV58', 'c585', 'cE87', 'c403', 'cV10', 'c038', 'c995', 'c424', 'c410', 'c780', 'c244', 'c997', 'c785', 'c305', 'c998', 'c458', 'c486', 'cV15', 'c041', 'c496', 'c996', 'c287', 'cV12', 'c790', 'c507', 'cE93', 'c493', 'c311', 'c511', 'c412', 'c707', 'c348', 'c765', 'cE88', 'c571', 'c300', 'c733'])\n",
+      "(PythonRDD[141] at RDD at PythonRDD.scala:53, ['c401', 'c427', 'c276', 'c272', 'c414', 'c518', 'c285', 'c250', 'c428', 'c584', 'cV45', 'c599', 'c530', 'cE87', 'cV58', 'c038', 'cV10', 'c410', 'c424', 'c997', 'c995', 'c585', 'c780', 'c785', 'c998', 'c458', 'c403', 'c305', 'c486', 'c041', 'c244', 'cV15', 'c496', 'c287', 'c996', 'c790', 'c507', 'cE93', 'cV12', 'c511', 'c348', 'c765', 'c311', 'cE88', 'c412', 'c493', 'cV29', 'c707', 'c774', 'c300'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print (get_id_to_topicd9(\"hadm_id\", True, 50))\n",
+    "print (get_id_to_topicd9(\"subject_id\", True, 50))\n",
+    "print (get_id_to_topicd9(\"hadm_id\", False, 50))\n",
+    "print (get_id_to_topicd9(\"subject_id\", False, 50))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Obtain dataframe for the merged noteevents and ID-to-ICD9 mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "def sparse2vec(mapper, data):\n",
+    "    out = [0] * len(mapper)\n",
+    "    if data != None:\n",
+    "        for i in data:\n",
+    "            out[mapper[i]] = 1\n",
+    "    return out\n",
+    "    \n",
+    "def get_id_to_texticd9(id_type, topX, stopwords=[]):\n",
+    "    def remstopwords(text):\n",
+    "        text = re.sub('\\[\\*\\*[^\\]]*\\*\\*\\]', '', text)\n",
+    "        text = re.sub('<[^>]*>', '', text)\n",
+    "        text = re.sub('[\\W]+', ' ', text.lower()) \n",
+    "        text = re.sub(\" \\d+\", \" \", text)\n",
+    "        return \" \".join([i for i in text.split() if i not in stopwords])\n",
+    "    \n",
+    "    id_to_topicd9code, topicd9code = get_id_to_topicd9(id_type, True, topX)\n",
+    "    id_to_topicd9cat, topicd9cat = get_id_to_topicd9(id_type, False, topX)\n",
+    "    topX2 = 2 * topX\n",
+    "    topicd9 = topicd9code+topicd9cat\n",
+    "    mapper = dict(zip(topicd9, range(topX2)))\n",
+    "    \n",
+    "    id_to_topicd9 = id_to_topicd9code.fullOuterJoin(id_to_topicd9cat) \\\n",
+    "        .map(lambda id_icd9code_icd9cat: (id_icd9code_icd9cat[0], \\\n",
+    "                                                 (id_icd9code_icd9cat[1][0] if id_icd9code_icd9cat[1][0] else set()) | \\\n",
+    "                                                 (id_icd9code_icd9cat[1][1] if id_icd9code_icd9cat[1][1] else set())))\n",
+    "        \n",
+    "    ne_topX = df_ne.rdd \\\n",
+    "        .filter(lambda x: x.category == \"Discharge summary\") \\\n",
+    "        .map(lambda x: (x.hadm_id if id_type==\"hadm_id\" else x.subject_id, x.text)) \\\n",
+    "        .groupByKey() \\\n",
+    "        .mapValues(lambda x: \" \".join(x)) \\\n",
+    "        .leftOuterJoin(id_to_topicd9) \\\n",
+    "        .map(lambda id_text_icd9: \\\n",
+    "             [id_text_icd9[0]]+sparse2vec(mapper, id_text_icd9[1][1])+[id_text_icd9[1][0] if len(stopwords) == 0 else remstopwords(id_text_icd9[1][0])])\n",
+    "#              list(Vectors.sparse(topX, dict.fromkeys(map(lambda x: mapper[x], icd9), 1))))\n",
+    "            \n",
+    "    return spark.createDataFrame(ne_topX, [\"id\"]+topicd9+[\"text\"]), topicd9\n",
+    "\n",
+    "# get_id_to_texticd9(\"hadm_id\", 10)[0].show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make list of unique ICD9CODES"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pickle\n",
+    "\n",
+    "ICD9CODES = spark.sql(\"\"\"\n",
+    "SELECT DISTINCT icd9_code FROM diagnoses_icd_m2\n",
+    "\"\"\").rdd.map(lambda x: x.icd9_code).collect()\n",
+    "ICD9CODES = [str(i).lower() for i in ICD9CODES]\n",
+    "\n",
+    "pickle.dump(ICD9CODES, open( \"./data/ICD9CODES.p\", \"wb\" ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Output to csv file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['4019', '4280', '42731', '41401', '5849', '25000', '2724', '51881', '5990', '53081', '2720', '2859', '2449', '486', '2851', '2762', '496', '99592', 'V5861', '5070', '0389', '5859', '40390', '311', '3051', '412', '2875', '41071', '2761', 'V4581', '4240', 'V1582', '5119', 'V4582', '40391', 'V290', '4241', '78552', 'V5867', '42789', '32723', '9971', '5845', '2760', '7742', '5180', 'V053', '4168', '49390', '2767', 'c401', 'c427', 'c276', 'c272', 'c414', 'c250', 'c428', 'c518', 'c285', 'c584', 'cV45', 'c599', 'c530', 'cV58', 'c585', 'cE87', 'c403', 'cV10', 'c038', 'c995', 'c424', 'c410', 'c780', 'c244', 'c997', 'c785', 'c305', 'c998', 'c458', 'c486', 'cV15', 'c041', 'c496', 'c996', 'c287', 'cV12', 'c790', 'c507', 'cE93', 'c493', 'c311', 'c511', 'c412', 'c707', 'c348', 'c765', 'cE88', 'c571', 'c300', 'c733']\n",
+      "52726\n",
+      "207.41420817375183\n",
+      "+------+----+----+-----+-----+----+-----+----+-----+----+-----+----+----+----+---+----+----+---+-----+-----+----+----+----+-----+---+----+---+----+-----+----+-----+----+-----+----+-----+-----+----+----+-----+-----+-----+-----+----+----+----+----+----+----+----+-----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+--------------------+\n",
+      "|    id|4019|4280|42731|41401|5849|25000|2724|51881|5990|53081|2720|2859|2449|486|2851|2762|496|99592|V5861|5070|0389|5859|40390|311|3051|412|2875|41071|2761|V4581|4240|V1582|5119|V4582|40391|V290|4241|78552|V5867|42789|32723|9971|5845|2760|7742|5180|V053|4168|49390|2767|c401|c427|c276|c272|c414|c250|c428|c518|c285|c584|cV45|c599|c530|cV58|c585|cE87|c403|cV10|c038|c995|c424|c410|c780|c244|c997|c785|c305|c998|c458|c486|cV15|c041|c496|c996|c287|cV12|c790|c507|cE93|c493|c311|c511|c412|c707|c348|c765|cE88|c571|c300|c733|                text|\n",
+      "+------+----+----+-----+-----+----+-----+----+-----+----+-----+----+----+----+---+----+----+---+-----+-----+----+----+----+-----+---+----+---+----+-----+----+-----+----+-----+----+-----+-----+----+----+-----+-----+-----+-----+----+----+----+----+----+----+----+-----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+--------------------+\n",
+      "|117760|   0|   0|    0|    0|   0|    0|   0|    1|   0|    1|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|\"Admission Date: ...|\n",
+      "|129030|   1|   0|    0|    0|   0|    0|   1|    0|   0|    1|   0|   1|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   1|   0|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date:  ...|\n",
+      "|172040|   0|   0|    0|    1|   1|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   1|   0|   0|    0|  0|   0|  0|   0|    1|   0|    0|   0|    1|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   1|   0|   0|   1|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   1|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|Admission Date:  ...|\n",
+      "|195500|   1|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   1|   0|   0|    0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   1|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date:  ...|\n",
+      "|156170|   0|   1|    1|    0|   1|    1|   0|    0|   0|    0|   0|   0|   1|  0|   0|   0|  0|    0|    1|   0|   0|   1|    1|  0|   0|  0|   0|    0|   0|    1|   0|    0|   0|    0|    0|   0|   0|    0|    0|    1|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   1|   0|   0|   0|   1|   1|   0|   1|   1|   1|   0|   0|   1|   1|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date:  ...|\n",
+      "|199180|   0|   1|    0|    1|   0|    1|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   1|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   1|   1|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   1|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date:  ...|\n",
+      "|167440|   0|   0|    0|    1|   0|    1|   0|    1|   0|    0|   1|   0|   0|  1|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   1|  0|   0|    0|   0|    0|   0|    0|   0|    1|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   1|   1|   1|   0|   1|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|\"Admission Date: ...|\n",
+      "|194580|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    1|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date:  ...|\n",
+      "|178710|   0|   0|    0|    0|   1|    0|   0|    0|   0|    0|   0|   0|   0|  1|   0|   0|  0|    0|    0|   0|   0|   1|    1|  0|   1|  0|   1|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   1|   0|   1|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   1|   0|   1|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|\"Admission Date: ...|\n",
+      "|162840|   0|   1|    1|    0|   0|    0|   1|    0|   0|    0|   0|   1|   1|  0|   0|   0|  1|    0|    1|   0|   0|   0|    1|  1|   0|  0|   0|    0|   0|    1|   1|    1|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   1|    0|   0|   0|   1|   0|   1|   1|   0|   1|   0|   1|   0|   1|   0|   0|   1|   1|   0|   1|   0|   0|   0|   1|   0|   0|   1|   0|   0|   0|   0|   1|   0|   1|   0|   1|   0|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date:  ...|\n",
+      "|189980|   1|   1|    0|    0|   0|    1|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   1|   0|   0|   0|   0|   1|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date: [...|\n",
+      "|142370|   0|   1|    0|    1|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  1|   0|  1|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   1|    0|    0|    1|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   1|   0|   0|   1|   0|   1|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   1|   0|   0|   0|   0|   0|   0|   0|\"Admission Date: ...|\n",
+      "|185380|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   1|   0|    0|    0|    0|    0|   0|   0|   0|   1|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|Unit No:  [**Nume...|\n",
+      "|169510|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   1|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|Admission Date:  ...|\n",
+      "|153640|   0|   0|    0|    1|   0|    0|   0|    1|   0|    0|   0|   1|   0|  1|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    1|   0|    0|   0|    0|   0|    1|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   1|   0|   0|   1|   0|   1|   0|   0|   1|   1|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date:  ...|\n",
+      "|196650|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   1|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date: [...|\n",
+      "|180780|   0|   0|    0|    0|   1|    0|   0|    1|   0|    0|   0|   1|   0|  0|   0|   0|  0|    1|    0|   1|   1|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    1|    0|    0|    0|   0|   0|   1|   0|   0|   0|   0|    0|   0|   0|   0|   1|   0|   0|   1|   0|   1|   1|   1|   0|   0|   0|   0|   0|   0|   0|   0|   1|   1|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|\"Admission Date: ...|\n",
+      "|149040|   1|   0|    0|    1|   0|    0|   0|    1|   0|    0|   0|   1|   0|  1|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  1|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   1|   0|   0|   0|   1|   0|   0|   1|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   1|   0|   0|   0|   0|   0|\"Admission Date: ...|\n",
+      "|117300|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date:  ...|\n",
+      "|196190|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|Admission Date:  ...|\n",
+      "+------+----+----+-----+-----+----+-----+----+-----+----+-----+----+----+----+---+----+----+---+-----+-----+----+----+----+-----+---+----+---+----+-----+----+-----+----+-----+----+-----+-----+----+----+-----+-----+-----+-----+----+----+----+----+----+----+----+-----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+--------------------+\n",
+      "only showing top 20 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "t0 = time.time()\n",
+    "\n",
+    "df_id2texticd9, topicd9 = get_id_to_texticd9(\"hadm_id\", 50)\n",
+    "df_id2texticd9.write.csv(\"./data/DATA_HADM\", header=True)\n",
+    "\n",
+    "print (topicd9)\n",
+    "print (df_id2texticd9.count())\n",
+    "print (time.time() - t0)\n",
+    "\n",
+    "df_id2texticd9.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['4019', '4280', '42731', '41401', '5849', '25000', '2724', '51881', '5990', '53081']\n",
+      "['4019', '4280', '42731', '41401', '5849', '25000', '2724', '51881', '5990', '53081', '2720', '2859', '2449', '486', '2851', '2762', '496', '99592', 'V5861', '5070', '0389', '5859', '40390', '311', '3051', '412', '2875', '41071', '2761', 'V4581', '4240', 'V1582', '5119', 'V4582', '40391', 'V290', '4241', '78552', 'V5867', '42789', '32723', '9971', '5845', '2760', '7742', '5180', 'V053', '4168', '49390', '2767']\n",
+      "['c401', 'c427', 'c276', 'c272', 'c414', 'c250', 'c428', 'c518', 'c285', 'c584']\n",
+      "['c401', 'c427', 'c276', 'c272', 'c414', 'c250', 'c428', 'c518', 'c285', 'c584', 'cV45', 'c599', 'c530', 'cV58', 'c585', 'cE87', 'c403', 'cV10', 'c038', 'c995', 'c424', 'c410', 'c780', 'c244', 'c997', 'c785', 'c305', 'c998', 'c458', 'c486', 'cV15', 'c041', 'c496', 'c996', 'c287', 'cV12', 'c790', 'c507', 'cE93', 'c493', 'c311', 'c511', 'c412', 'c707', 'c348', 'c765', 'cE88', 'c571', 'c300', 'c733']\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pickle\n",
+    "\n",
+    "print topicd9[:10]\n",
+    "pickle.dump(topicd9[:10], open( \"./data/ICD9CODES_TOP10.p\", \"wb\" ))\n",
+    "print topicd9[:50]\n",
+    "pickle.dump(topicd9[:50], open( \"./data/ICD9CODES_TOP50.p\", \"wb\" ))\n",
+    "print topicd9[50:60]\n",
+    "pickle.dump(topicd9[50:60], open( \"./data/ICD9CAT_TOP10.p\", \"wb\" ))\n",
+    "print topicd9[50:]\n",
+    "pickle.dump(topicd9[50:], open( \"./data/ICD9CAT_TOP50.p\", \"wb\" ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['4019', '4280', '42731', '41401', '5849', '25000', '2724', '51881', '5990', '53081', '2720', '2859', '2449', '486', '2851', '2762', '496', '99592', 'V5861', '5070', '0389', '5859', '40390', '311', '3051', '412', '2875', '41071', '2761', 'V4581', '4240', 'V1582', '5119', 'V4582', '40391', 'V290', '4241', '78552', 'V5867', '42789', '32723', '9971', '5845', '2760', '7742', '5180', 'V053', '4168', '49390', '2767', 'c401', 'c427', 'c276', 'c272', 'c414', 'c250', 'c428', 'c518', 'c285', 'c584', 'cV45', 'c599', 'c530', 'cV58', 'c585', 'cE87', 'c403', 'cV10', 'c038', 'c995', 'c424', 'c410', 'c780', 'c244', 'c997', 'c785', 'c305', 'c998', 'c458', 'c486', 'cV15', 'c041', 'c496', 'c996', 'c287', 'cV12', 'c790', 'c507', 'cE93', 'c493', 'c311', 'c511', 'c412', 'c707', 'c348', 'c765', 'cE88', 'c571', 'c300', 'c733']\n",
+      "52726\n",
+      "6271.663594484329\n",
+      "+------+----+----+-----+-----+----+-----+----+-----+----+-----+----+----+----+---+----+----+---+-----+-----+----+----+----+-----+---+----+---+----+-----+----+-----+----+-----+----+-----+-----+----+----+-----+-----+-----+-----+----+----+----+----+----+----+----+-----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+--------------------+\n",
+      "|    id|4019|4280|42731|41401|5849|25000|2724|51881|5990|53081|2720|2859|2449|486|2851|2762|496|99592|V5861|5070|0389|5859|40390|311|3051|412|2875|41071|2761|V4581|4240|V1582|5119|V4582|40391|V290|4241|78552|V5867|42789|32723|9971|5845|2760|7742|5180|V053|4168|49390|2767|c401|c427|c276|c272|c414|c250|c428|c518|c285|c584|cV45|c599|c530|cV58|c585|cE87|c403|cV10|c038|c995|c424|c410|c780|c244|c997|c785|c305|c998|c458|c486|cV15|c041|c496|c996|c287|cV12|c790|c507|cE93|c493|c311|c511|c412|c707|c348|c765|cE88|c571|c300|c733|                text|\n",
+      "+------+----+----+-----+-----+----+-----+----+-----+----+-----+----+----+----+---+----+----+---+-----+-----+----+----+----+-----+---+----+---+----+-----+----+-----+----+-----+----+-----+-----+----+----+-----+-----+-----+-----+----+----+----+----+----+----+----+-----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+--------------------+\n",
+      "|117760|   0|   0|    0|    0|   0|    0|   0|    1|   0|    1|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|129030|   1|   0|    0|    0|   0|    0|   1|    0|   0|    1|   0|   1|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   1|   0|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|172040|   0|   0|    0|    1|   1|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   1|   0|   0|    0|  0|   0|  0|   0|    1|   0|    0|   0|    1|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   1|   0|   0|   1|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   1|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|admission date di...|\n",
+      "|195500|   1|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   1|   0|   0|    0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   1|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|156170|   0|   1|    1|    0|   1|    1|   0|    0|   0|    0|   0|   0|   1|  0|   0|   0|  0|    0|    1|   0|   0|   1|    1|  0|   0|  0|   0|    0|   0|    1|   0|    0|   0|    0|    0|   0|   0|    0|    0|    1|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   1|   0|   0|   0|   1|   1|   0|   1|   1|   1|   0|   0|   1|   1|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|199180|   0|   1|    0|    1|   0|    1|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   1|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   1|   1|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   1|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|167440|   0|   0|    0|    1|   0|    1|   0|    1|   0|    0|   1|   0|   0|  1|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   1|  0|   0|    0|   0|    0|   0|    0|   0|    1|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   1|   1|   1|   0|   1|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|admission date di...|\n",
+      "|194580|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    1|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|178710|   0|   0|    0|    0|   1|    0|   0|    0|   0|    0|   0|   0|   0|  1|   0|   0|  0|    0|    0|   0|   0|   1|    1|  0|   1|  0|   1|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   1|   0|   1|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   1|   0|   1|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|162840|   0|   1|    1|    0|   0|    0|   1|    0|   0|    0|   0|   1|   1|  0|   0|   0|  1|    0|    1|   0|   0|   0|    1|  1|   0|  0|   0|    0|   0|    1|   1|    1|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   1|    0|   0|   0|   1|   0|   1|   1|   0|   1|   0|   1|   0|   1|   0|   0|   1|   1|   0|   1|   0|   0|   0|   1|   0|   0|   1|   0|   0|   0|   0|   1|   0|   1|   0|   1|   0|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|189980|   1|   1|    0|    0|   0|    1|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   1|   0|   0|   0|   0|   1|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|142370|   0|   1|    0|    1|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  1|   0|  1|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   1|    0|    0|    1|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   1|   0|   0|   1|   0|   1|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   1|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|185380|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   1|   0|    0|    0|    0|    0|   0|   0|   0|   1|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|unit admission da...|\n",
+      "|169510|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   1|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|admission date di...|\n",
+      "|153640|   0|   0|    0|    1|   0|    0|   0|    1|   0|    0|   0|   1|   0|  1|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    1|   0|    0|   0|    0|   0|    1|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   1|   0|   0|   1|   0|   1|   0|   0|   1|   1|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|196650|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   1|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|180780|   0|   0|    0|    0|   1|    0|   0|    1|   0|    0|   0|   1|   0|  0|   0|   0|  0|    1|    0|   1|   1|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    1|    0|    0|    0|   0|   0|   1|   0|   0|   0|   0|    0|   0|   0|   0|   1|   0|   0|   1|   0|   1|   1|   1|   0|   0|   0|   0|   0|   0|   0|   0|   1|   1|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|149040|   1|   0|    0|    1|   0|    0|   0|    1|   0|    0|   0|   1|   0|  1|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  1|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   1|   0|   0|   0|   1|   0|   0|   1|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   1|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|117300|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "|196190|   0|   0|    0|    0|   0|    0|   0|    0|   0|    0|   0|   0|   0|  0|   0|   0|  0|    0|    0|   0|   0|   0|    0|  0|   0|  0|   0|    0|   0|    0|   0|    0|   0|    0|    0|   0|   0|    0|    0|    0|    0|   0|   0|   0|   0|   0|   0|   0|    0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   1|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|   0|admission date di...|\n",
+      "+------+----+----+-----+-----+----+-----+----+-----+----+-----+----+----+----+---+----+----+---+-----+-----+----+----+----+-----+---+----+---+----+-----+----+-----+----+-----+----+-----+-----+----+----+-----+-----+-----+-----+----+----+----+----+----+----+----+-----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+--------------------+\n",
+      "only showing top 20 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "from nltk.corpus import stopwords\n",
+    "\n",
+    "t0 = time.time()\n",
+    "STOPWORDS_WORD2VEC = stopwords.words('english') + ICD9CODES\n",
+    "\n",
+    "df_id2texticd9, topicd9 = get_id_to_texticd9(\"hadm_id\", 50, stopwords=STOPWORDS_WORD2VEC)\n",
+    "df_id2texticd9.write.csv(\"./data/DATA_HADM_CLEANED\", header=True)\n",
+    "df_id2texticd9.cache()\n",
+    "\n",
+    "print (topicd9)\n",
+    "print (df_id2texticd9.count())\n",
+    "print (time.time() - t0)\n",
+    "df_id2texticd9.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test csv file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       id  4019  4280  42731  41401  5849  25000  2724  51881  5990  ...  \\\n",
+      "0  117760     0     0      0      0     0      0     0      1     0  ...   \n",
+      "1  129030     1     0      0      0     0      0     1      0     0  ...   \n",
+      "2  172040     0     0      0      1     1      0     0      0     0  ...   \n",
+      "3  195500     1     0      0      0     0      0     0      0     0  ...   \n",
+      "4  156170     0     1      1      0     1      1     0      0     0  ...   \n",
+      "\n",
+      "   c511  c412  c707  c348  c765  cE88  c571  c300  c733  \\\n",
+      "0     0     0     0     1     0     0     0     0     0   \n",
+      "1     0     0     0     0     0     0     0     0     0   \n",
+      "2     0     0     0     0     0     1     0     0     0   \n",
+      "3     0     0     0     0     0     0     0     0     0   \n",
+      "4     0     0     0     0     0     0     0     0     0   \n",
+      "\n",
+      "                                                text  \n",
+      "0  \"Admission Date:  [**2118-12-14**]            ...  \n",
+      "1  Admission Date:  [**2137-8-31**]              ...  \n",
+      "2  Admission Date:  [**2174-1-6**]              D...  \n",
+      "3  Admission Date:  [**2196-9-21**]              ...  \n",
+      "4  Admission Date:  [**2102-6-9**]              D...  \n",
+      "\n",
+      "[5 rows x 102 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "df = pd.read_csv(\"./data/DATA_HADM\", escapechar='\\\\')\n",
+    "print (df.head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test by counting rows (depreciated)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+\n",
+      "|icd9_code|\n",
+      "+---------+\n",
+      "|     4019|\n",
+      "|     4280|\n",
+      "|    42731|\n",
+      "|    41401|\n",
+      "|     5849|\n",
+      "|    25000|\n",
+      "|     2724|\n",
+      "|    51881|\n",
+      "|     5990|\n",
+      "|    53081|\n",
+      "+---------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "spark.sql(\"\"\"\n",
+    "SELECT icd9_code\n",
+    "FROM diagnoses_icd_m2\n",
+    "GROUP BY icd9_code\n",
+    "ORDER BY COUNT(DISTINCT hadm_id) DESC\n",
+    "LIMIT 10\n",
+    "\"\"\").show()\n",
+    "    \n",
+    "# id_to_topicd9, topicd9 = get_id_to_topicd9(\"hadm_id\", 10)\n",
+    "# print id_to_topicd9.count()\n",
+    "\n",
+    "# spark.sql(\"\"\"\n",
+    "# SELECT COUNT(DISTINCT hadm_id) AS hadm_count\n",
+    "# FROM diagnoses_icd_m2\n",
+    "# WHERE icd9_code IN\n",
+    "#     (SELECT icd9_code\n",
+    "#     FROM diagnoses_icd_m2\n",
+    "#     GROUP BY icd9_code\n",
+    "#     ORDER BY COUNT(DISTINCT hadm_id) DESC\n",
+    "#     LIMIT 10)\n",
+    "# \"\"\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done!\n"
+     ]
+    }
+   ],
+   "source": [
+    "#sc.stop()\n",
+    "print (\"Done!\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/code/python3/preprocess.py
+++ b/code/python3/preprocess.py
@@ -1,0 +1,277 @@
+from pyspark import SparkContext, SparkConf
+from pyspark.sql.types import *
+import pyspark.sql.functions as F
+from pyspark.sql import SparkSession
+
+conf = SparkConf().setAppName("preprocess").setMaster("local")
+sc = SparkContext.getOrCreate(conf)
+spark = SparkSession.builder.master("local").appName("preprocess").getOrCreate()
+
+ne_struct = StructType([StructField("row_id", IntegerType(), True),
+                      StructField("subject_id", IntegerType(), True),
+                      StructField("hadm_id", IntegerType(), True),
+                      StructField("chartdate", DateType(), True),
+                      StructField("category", StringType(), True),
+                      StructField("description", StringType(), True),
+                      StructField("cgid", IntegerType(), True),
+                      StructField("iserror", IntegerType(), True),
+                      StructField("text", StringType(), True)])
+df_ne = spark.read.csv("./data/NOTEEVENTS-2.csv",
+# df_ne = spark.read.csv("./data/NOTEEVENTS-2sample.csv",
+                       header=True,
+                       schema=ne_struct)
+df_ne.registerTempTable("noteevents")
+df_ne.filter(df_ne.category=="Discharge summary") \
+    .registerTempTable("noteevents2")
+
+# i want to cache noteevents, but it's too big
+
+# many icd to one hadm_id
+diag_struct = StructType([StructField("ROW_ID", IntegerType(), True),
+                          StructField("SUBJECT_ID", IntegerType(), True),
+                          StructField("HADM_ID", IntegerType(), True),
+                          StructField("SEQ_NUM", IntegerType(), True),
+                          StructField("ICD9_CODE", StringType(), True)])
+df_diag_m = spark.read.csv("./data/DIAGNOSES_ICD.csv",
+                           header=True,
+                           schema=diag_struct) \
+            .selectExpr("ROW_ID as row_id",
+                        "SUBJECT_ID as subject_id",
+                        "HADM_ID as hadm_id",
+                        "SEQ_NUM as seq_num",
+                        "ICD9_CODE as icd9_code")
+# added to filter out categories
+geticd9cat_udf = F.udf(lambda x: str(x)[:3], StringType())
+df_diag_m = df_diag_m.withColumn("icd9_cat", geticd9cat_udf("icd9_code"))
+df_diag_m.registerTempTable("diagnoses_icd_m")
+df_diag_m.cache()
+
+# one icd to one hadm_id (take the smallest seq number as primary)
+diag_o_rdd = df_diag_m.rdd.sortBy(lambda x: (x.hadm_id, x.subject_id, x.seq_num)) \
+    .groupBy(lambda x: x.hadm_id) \
+    .mapValues(list) \
+    .reduceByKey(lambda x, y: x if x.seq_num < y.seq_num else y) \
+    .map(lambda hid_d: hid_d[1][0])
+df_diag_o = spark.createDataFrame(diag_o_rdd)
+df_diag_o.registerTempTable("diagnoses_icd_o")
+df_diag_o.cache()
+
+# get hadm_id list in noteevents
+df_hadm_id_list = spark.sql("""
+SELECT DISTINCT hadm_id FROM noteevents2
+""")
+df_hadm_id_list.registerTempTable("hadm_id_list")
+df_hadm_id_list.cache()
+
+# get subject_id list in noteevents
+df_subject_id_list = spark.sql("""
+SELECT DISTINCT subject_id FROM noteevents2
+""")
+df_subject_id_list.registerTempTable("subject_id_list")
+df_subject_id_list.cache()
+
+df_icd9desc = spark.read.csv("./data/D_ICD_DIAGNOSES.csv",
+                       header=True, inferSchema=True)
+df_icd9desc.registerTempTable("diagnoses_icd_desc")
+
+df_diag_o2 = spark.sql("""
+SELECT row_id, subject_id, diagnoses_icd_o.hadm_id AS hadm_id,
+seq_num, icd9_code, icd9_cat
+FROM diagnoses_icd_o JOIN hadm_id_list
+ON diagnoses_icd_o.hadm_id = hadm_id_list.hadm_id
+""")
+df_diag_o2.registerTempTable("diagnoses_icd_o2")
+df_diag_o2.cache()
+
+df_diag_m2 = spark.sql("""
+SELECT row_id, subject_id, diagnoses_icd_m.hadm_id AS hadm_id,
+seq_num, icd9_code, icd9_cat
+FROM diagnoses_icd_m JOIN hadm_id_list
+ON diagnoses_icd_m.hadm_id = hadm_id_list.hadm_id
+""")
+df_diag_m2.registerTempTable("diagnoses_icd_m2")
+df_diag_m2.cache()
+
+print (df_ne.dtypes)
+print (df_diag_m.dtypes)
+print (df_diag_o.dtypes)
+print (df_hadm_id_list.dtypes)
+print (df_subject_id_list.dtypes)
+print (df_icd9desc.dtypes)
+print (df_diag_o2.dtypes)
+print (df_diag_m2.dtypes)
+
+icd9code_score_hadm = spark.sql("""
+SELECT icd9_code, COUNT(DISTINCT hadm_id) AS score
+FROM diagnoses_icd_m2
+GROUP BY icd9_code
+""").rdd.cache()
+
+icd9code_score_subj = spark.sql("""
+SELECT icd9_code, COUNT(DISTINCT subject_id) AS score
+FROM diagnoses_icd_m2
+GROUP BY icd9_code
+""").rdd.cache()
+
+icd9cat_score_hadm = spark.sql("""
+SELECT icd9_cat AS icd9_code, COUNT(DISTINCT hadm_id) AS score
+FROM diagnoses_icd_m2
+GROUP BY icd9_cat
+""").rdd.cache()
+
+icd9cat_score_subj = spark.sql("""
+SELECT icd9_cat AS icd9_code, COUNT(DISTINCT subject_id) AS score
+FROM diagnoses_icd_m2
+GROUP BY icd9_cat
+""").rdd.cache()
+
+def get_id_to_topicd9(id_type, icdcode, topX):
+    if id_type == "hadm_id" and icdcode:
+        icd9_score = icd9code_score_hadm
+    elif id_type == "hadm_id" and not icdcode:
+        icd9_score = icd9cat_score_hadm
+    elif id_type == "subject_id" and icdcode:
+        icd9_score = icd9code_score_subj
+    elif id_type == "subject_id" and not icdcode:
+        icd9_score = icd9cat_score_subj
+    else: #default
+        icd9_score = icd9code_score_hadm
+
+
+    icd9_topX2 = [i.icd9_code for i in icd9_score.takeOrdered(topX, key=lambda x: -x.score)]
+    if not icdcode:
+        icd9_topX2 = ['c'+str(i) for i in icd9_topX2]
+    else:
+        icd9_topX2 = [str(i) for i in icd9_topX2]
+    icd9_topX = set(icd9_topX2)
+
+    id_to_topicd9 = df_diag_m2.rdd \
+        .map(lambda x: (x.hadm_id if id_type=="hadm_id" else x.subject_id, x.icd9_code if icdcode else 'c'+str(x.icd9_cat))) \
+        .groupByKey() \
+        .mapValues(lambda x: set(x) & icd9_topX) \
+        .filter(lambda x_y: x_y[1])
+
+    return id_to_topicd9, list(icd9_topX2)
+
+print (get_id_to_topicd9("hadm_id", True, 50))
+print (get_id_to_topicd9("subject_id", True, 50))
+print (get_id_to_topicd9("hadm_id", False, 50))
+print (get_id_to_topicd9("subject_id", False, 50))
+
+import re
+
+def sparse2vec(mapper, data):
+    out = [0] * len(mapper)
+    if data != None:
+        for i in data:
+            out[mapper[i]] = 1
+    return out
+
+def get_id_to_texticd9(id_type, topX, stopwords=[]):
+    def remstopwords(text):
+        text = re.sub('\[\*\*[^\]]*\*\*\]', '', text)
+        text = re.sub('<[^>]*>', '', text)
+        text = re.sub('[\W]+', ' ', text.lower())
+        text = re.sub(" \d+", " ", text)
+        return " ".join([i for i in text.split() if i not in stopwords])
+
+    id_to_topicd9code, topicd9code = get_id_to_topicd9(id_type, True, topX)
+    id_to_topicd9cat, topicd9cat = get_id_to_topicd9(id_type, False, topX)
+    topX2 = 2 * topX
+    topicd9 = topicd9code+topicd9cat
+    mapper = dict(zip(topicd9, range(topX2)))
+
+    id_to_topicd9 = id_to_topicd9code.fullOuterJoin(id_to_topicd9cat) \
+        .map(lambda id_icd9code_icd9cat: (id_icd9code_icd9cat[0], \
+                                          (id_icd9code_icd9cat[1][0] if id_icd9code_icd9cat[1][0] else set()) | \
+                                          (id_icd9code_icd9cat[1][1] if id_icd9code_icd9cat[1][1] else set())))
+
+    ne_topX = df_ne.rdd \
+        .filter(lambda x: x.category == "Discharge summary") \
+        .map(lambda x: (x.hadm_id if id_type=="hadm_id" else x.subject_id, x.text)) \
+        .groupByKey() \
+        .mapValues(lambda x: " ".join(x)) \
+        .leftOuterJoin(id_to_topicd9) \
+        .map(lambda id_text_icd9: \
+             [id_text_icd9[0]]+sparse2vec(mapper, id_text_icd9[1][1])+[id_text_icd9[1][0] if len(stopwords) == 0 else remstopwords(id_text_icd9[1][0])])
+#              list(Vectors.sparse(topX, dict.fromkeys(map(lambda x: mapper[x], icd9), 1))))
+
+    return spark.createDataFrame(ne_topX, ["id"]+topicd9+["text"]), topicd9
+
+# get_id_to_texticd9("hadm_id", 10)[0].show()
+
+import pickle
+
+ICD9CODES = spark.sql("""
+SELECT DISTINCT icd9_code FROM diagnoses_icd_m2
+""").rdd.map(lambda x: x.icd9_code).collect()
+ICD9CODES = [str(i).lower() for i in ICD9CODES]
+
+pickle.dump(ICD9CODES, open( "./data/ICD9CODES.p", "wb" ))
+
+import time
+t0 = time.time()
+
+df_id2texticd9, topicd9 = get_id_to_texticd9("hadm_id", 50)
+df_id2texticd9.write.csv("./data/DATA_HADM", header=True)
+
+print (topicd9)
+print (df_id2texticd9.count())
+print (time.time() - t0)
+
+df_id2texticd9.show()
+
+import pickle
+
+print (topicd9[:10])
+pickle.dump(topicd9[:10], open( "./data/ICD9CODES_TOP10.p", "wb" ))
+print (topicd9[:50])
+pickle.dump(topicd9[:50], open( "./data/ICD9CODES_TOP50.p", "wb" ))
+print (topicd9[50:60])
+pickle.dump(topicd9[50:60], open( "./data/ICD9CAT_TOP10.p", "wb" ))
+print (topicd9[50:])
+pickle.dump(topicd9[50:], open( "./data/ICD9CAT_TOP50.p", "wb" ))
+
+import time
+from nltk.corpus import stopwords
+
+t0 = time.time()
+STOPWORDS_WORD2VEC = stopwords.words('english') + ICD9CODES
+
+df_id2texticd9, topicd9 = get_id_to_texticd9("hadm_id", 50, stopwords=STOPWORDS_WORD2VEC)
+df_id2texticd9.write.csv("./data/DATA_HADM_CLEANED", header=True)
+df_id2texticd9.cache()
+
+print (topicd9)
+print (df_id2texticd9.count())
+print (time.time() - t0)
+df_id2texticd9.show()
+
+import pandas as pd
+df = pd.read_csv("./data/DATA_HADM.csv", escapechar='\\')
+print (df.head())
+
+spark.sql("""
+SELECT icd9_code
+FROM diagnoses_icd_m2
+GROUP BY icd9_code
+ORDER BY COUNT(DISTINCT hadm_id) DESC
+LIMIT 10
+""").show()
+
+# id_to_topicd9, topicd9 = get_id_to_topicd9("hadm_id", 10)
+# print id_to_topicd9.count()
+
+# spark.sql("""
+# SELECT COUNT(DISTINCT hadm_id) AS hadm_count
+# FROM diagnoses_icd_m2
+# WHERE icd9_code IN
+#     (SELECT icd9_code
+#     FROM diagnoses_icd_m2
+#     GROUP BY icd9_code
+#     ORDER BY COUNT(DISTINCT hadm_id) DESC
+#     LIMIT 10)
+# """).show()
+
+#sc.stop()
+print ("Done!")


### PR DESCRIPTION
Since Python2 is completely shut down, I've started to update the pipeline to be compatible with Python3. First step: `preprocess`. 
Changes mainly include:
* Adding `()` for `print` functions,
* Handling lambda auto tuple unpacking (which has been removed from python2)
* Updating gitignore to ignore the jupyter notebook checkpoints.